### PR TITLE
Fix 403 installation error - Add comprehensive deployment documentation

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,296 @@
+# Complete Deployment Guide for TiddlyWiki Home Assistant Add-on
+
+This guide walks you through the complete process of deploying your addon so users can install it.
+
+## 📋 Prerequisites Checklist
+
+Before deployment:
+- ✅ All code is committed and pushed to feature branch
+- ✅ All tests pass (YAML validation, bash syntax, etc.)
+- ✅ Documentation is complete
+- ✅ LICENSE file is present
+- ✅ CHANGELOG.md is updated
+- ✅ Icon and logo files exist
+
+## 🚀 Deployment Steps
+
+### Step 1: Create Main Branch
+
+**Currently your repo has NO main branch!** This is why images aren't built.
+
+```bash
+# Option A: Create main from current feature branch
+git checkout claude/review-previous-work-011CUuddWCWqDdX3EGaRui9T
+git checkout -b main
+git push -u origin main
+
+# Option B: Via GitHub UI
+# Go to: https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki
+# Click branch dropdown, type "main", click "Create branch: main"
+```
+
+### Step 2: Trigger GitHub Actions Build
+
+Once main branch exists, GitHub Actions will automatically build:
+
+**Monitor the build:**
+```
+https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki/actions
+```
+
+**What gets built:**
+- ✅ amd64-hassio-tiddlywiki
+- ✅ armhf-hassio-tiddlywiki
+- ✅ armv7-hassio-tiddlywiki
+- ✅ aarch64-hassio-tiddlywiki
+- ✅ i386-hassio-tiddlywiki
+
+**Build time:** ~5-10 minutes for all architectures
+
+**Build artifacts:** Docker images pushed to GHCR
+
+### Step 3: Make Packages Public (CRITICAL!)
+
+**By default, GHCR packages are PRIVATE.** You must make them public:
+
+1. **Navigate to packages:**
+   ```
+   https://github.com/BenSweaterVest?tab=packages
+   ```
+
+2. **For EACH of the 5 packages:**
+
+   a. Click package name (e.g., `amd64-hassio-tiddlywiki`)
+
+   b. Click "Package settings" (right sidebar)
+
+   c. Scroll to "Danger Zone" section
+
+   d. Click "Change visibility"
+
+   e. Select "Public"
+
+   f. Type package name to confirm
+
+   g. Click "I understand, change package visibility"
+
+3. **Verify all 5 packages show "Public" badge**
+
+**Alternative: Automate with GitHub CLI (Advanced)**
+
+```bash
+# Install GitHub CLI if needed
+# brew install gh  # macOS
+# apt install gh   # Linux
+
+# Login
+gh auth login
+
+# Make packages public (run for each architecture)
+gh api \
+  --method PATCH \
+  -H "Accept: application/vnd.github+json" \
+  /user/packages/container/amd64-hassio-tiddlywiki/versions/latest \
+  -f visibility='public'
+
+# Repeat for: armhf, armv7, aarch64, i386
+```
+
+### Step 4: Verify Images Are Accessible
+
+Test pulling an image:
+
+```bash
+# Should work without authentication now
+docker pull ghcr.io/bensweetervest/amd64-hassio-tiddlywiki:latest
+
+# Check image exists
+docker images | grep tiddlywiki
+```
+
+### Step 5: Create GitHub Release (Optional but Recommended)
+
+```bash
+# Create and push tag
+git tag -a v1.0.0 -m "Release v1.0.0 - Initial production release"
+git push origin v1.0.0
+```
+
+Then via GitHub UI:
+1. Go to: https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki/releases/new
+2. Choose tag `v1.0.0`
+3. Title: `v1.0.0 - TiddlyWiki Home Assistant Add-on`
+4. Copy content from `RELEASE_NOTES_v1.0.0.md`
+5. Check "Set as the latest release"
+6. Click "Publish release"
+
+### Step 6: Test Installation in Home Assistant
+
+1. **Add Repository:**
+   - Settings → Add-ons → Add-on Store
+   - Click ⋮ menu → Repositories
+   - Add: `https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki`
+
+2. **Install Addon:**
+   - Find "TiddlyWiki" in addon list
+   - Click to open details
+   - Click "Install"
+   - Should download images successfully (no 403 errors!)
+
+3. **Configure & Start:**
+   - Set any desired configuration
+   - Click "Start"
+   - Click "Open Web UI"
+   - Verify TiddlyWiki loads
+
+## 🔍 Troubleshooting
+
+### Build Never Starts
+
+**Problem:** Pushed to main but no build triggered
+
+**Solutions:**
+- Verify push actually went to `main` branch
+- Check `.github/workflows/build.yml` exists
+- Check Actions tab is enabled in repository settings
+- Try manual trigger: Actions → Build TiddlyWiki Add-on → Run workflow
+
+### Build Fails
+
+**Common issues:**
+
+1. **"Target directory not found"**
+   - Verify `tiddlywiki/` directory exists
+   - Check `--target tiddlywiki` in build.yml
+
+2. **"Base image not found"**
+   - Check internet connectivity from GitHub Actions
+   - Verify base image tags in `build.yaml` are current
+
+3. **"Permission denied"**
+   - Check repository has Actions enabled
+   - Verify GITHUB_TOKEN has packages:write permission
+
+### Still Getting 403 After Build
+
+**Most common cause:** Packages are still private!
+
+**Fix:**
+1. Go to https://github.com/BenSweaterVest?tab=packages
+2. Verify all 5 packages show "Public" badge
+3. If not, follow Step 3 above to make them public
+
+**Other causes:**
+- Package names don't match (check for typos)
+- Wrong registry URL in config.yaml
+- Caching issue (wait a few minutes, try again)
+
+### Images Build but HA Can't Find Them
+
+**Check:**
+1. Package visibility is public
+2. Image names in config.yaml match actual package names
+3. Architecture is correct for your HA installation
+4. Repository URL is added correctly to HA
+
+## 📊 Deployment Checklist
+
+Use this checklist for each deployment:
+
+### Pre-Deployment
+- [ ] All changes committed
+- [ ] All tests pass
+- [ ] Version bumped in config.yaml
+- [ ] CHANGELOG.md updated
+- [ ] Documentation reviewed
+
+### Build Phase
+- [ ] Main branch exists
+- [ ] Pushed to main branch
+- [ ] GitHub Actions triggered
+- [ ] Build completed successfully
+- [ ] All 5 architectures built
+- [ ] Images appear in Packages tab
+
+### Visibility Phase
+- [ ] amd64-hassio-tiddlywiki is public
+- [ ] armhf-hassio-tiddlywiki is public
+- [ ] armv7-hassio-tiddlywiki is public
+- [ ] aarch64-hassio-tiddlywiki is public
+- [ ] i386-hassio-tiddlywiki is public
+
+### Testing Phase
+- [ ] Can manually pull images with docker
+- [ ] Repository adds successfully in HA
+- [ ] Addon appears in HA addon store
+- [ ] Addon installs without errors
+- [ ] Addon starts successfully
+- [ ] Web UI accessible
+- [ ] Wiki functions correctly
+
+### Release Phase (Optional)
+- [ ] Git tag created
+- [ ] Tag pushed to GitHub
+- [ ] GitHub release created
+- [ ] Release notes published
+- [ ] Release marked as latest
+
+## 🎯 Quick Reference
+
+### Essential URLs
+
+- **Repository:** https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki
+- **Actions:** https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki/actions
+- **Packages:** https://github.com/BenSweaterVest?tab=packages
+- **Releases:** https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki/releases
+
+### Image URLs (After Build)
+
+```
+ghcr.io/bensweetervest/amd64-hassio-tiddlywiki:latest
+ghcr.io/bensweetervest/armhf-hassio-tiddlywiki:latest
+ghcr.io/bensweetervest/armv7-hassio-tiddlywiki:latest
+ghcr.io/bensweetervest/aarch64-hassio-tiddlywiki:latest
+ghcr.io/bensweetervest/i386-hassio-tiddlywiki:latest
+```
+
+### Key Commands
+
+```bash
+# Create main and push
+git checkout -b main
+git push -u origin main
+
+# Check build status
+# Visit: https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki/actions
+
+# Test image pull
+docker pull ghcr.io/bensweetervest/amd64-hassio-tiddlywiki:latest
+
+# View packages
+# Visit: https://github.com/BenSweaterVest?tab=packages
+```
+
+## 📝 Notes
+
+- **First deployment takes longest** - subsequent builds are cached
+- **Making packages public is MANUAL** - must be done via UI for each package
+- **Architecture names must match exactly** - case-sensitive
+- **Latest tag is automatic** - created by builder along with version tags
+- **Users only need repository URL** - HA handles image pulling automatically
+
+## 🎉 Success Criteria
+
+Your addon is successfully deployed when:
+1. ✅ All 5 architecture images exist in GHCR
+2. ✅ All 5 packages are marked "Public"
+3. ✅ You can install via Home Assistant without errors
+4. ✅ The addon starts and functions correctly
+5. ✅ Users can add your repository URL and install
+
+---
+
+**Need Help?**
+- See `TROUBLESHOOTING_403.md` for 403 error fixes
+- Check GitHub Actions logs for build errors
+- Verify package settings if images exist but aren't accessible

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ TiddlyWiki is a powerful, flexible tool for organizing information. This add-on 
 
 ## Installation
 
+**⚠️ Note:** Docker images must be built and public before installation. See [DEPLOYMENT_GUIDE.md](DEPLOYMENT_GUIDE.md) if you're the maintainer, or wait for the first release to be published.
+
 1. In Home Assistant, navigate to **Settings** → **Add-ons** → **Add-on Store**
 2. Click the **⋮** menu in the top right → **Repositories**
 3. Add this repository URL: `https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki`
@@ -21,6 +23,8 @@ TiddlyWiki is a powerful, flexible tool for organizing information. This add-on 
 5. Click **Install**
 6. Configure the add-on (see Configuration section)
 7. Click **Start**
+
+**Getting 403 errors?** See [TROUBLESHOOTING_403.md](TROUBLESHOOTING_403.md)
 
 ## Documentation
 

--- a/RELEASE_INSTRUCTIONS.md
+++ b/RELEASE_INSTRUCTIONS.md
@@ -1,5 +1,33 @@
 # How to Create v1.0.0 Release
 
+## ⚠️ IMPORTANT: Build Images First!
+
+**Before creating the release, you MUST build the Docker images.**
+
+Currently, your repository has NO `main` branch, which means:
+- ❌ GitHub Actions has never run
+- ❌ No Docker images have been built
+- ❌ Images don't exist in GHCR
+- ❌ Users will get 403 errors trying to install
+
+**See `TROUBLESHOOTING_403.md` for complete fix instructions.**
+
+## Quick Fix
+
+```bash
+# Create main branch from feature branch
+git checkout claude/review-previous-work-011CUuddWCWqDdX3EGaRui9T
+git checkout -b main
+git push -u origin main
+
+# Wait 5-10 minutes for build to complete
+# Monitor at: https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki/actions
+
+# Then make packages public (see TROUBLESHOOTING_403.md)
+```
+
+---
+
 ## Current Status
 
 ✅ **Tag created locally**: v1.0.0

--- a/TROUBLESHOOTING_403.md
+++ b/TROUBLESHOOTING_403.md
@@ -1,0 +1,181 @@
+# Fixing the 403 GHCR Installation Error
+
+## 🔍 Issue Analysis
+
+**Error Message:**
+```
+Can't install ghcr.io/bensweetervest/amd64-hassio-tiddlywiki:1.0.0: 403 Client Error
+Forbidden ("Head "https://ghcr.io/v2/bensweetervest/amd64-hassio-tiddlywiki/manifests/1.0.0": denied")
+```
+
+## 🎯 Root Cause
+
+**The Docker images have not been built yet!**
+
+Here's what's happening:
+1. ✅ Your code is on the feature branch: `claude/review-previous-work-011CUuddWCWqDdX3EGaRui9T`
+2. ❌ **There is no `main` branch** in your repository yet
+3. ❌ GitHub Actions workflow only triggers on push to `main` (see `.github/workflows/build.yml` line 5)
+4. ❌ No images have been built or pushed to GHCR
+5. ❌ When Home Assistant tries to pull the images, they don't exist → 403 Forbidden
+
+**The 403 error doesn't mean "private" in this case - it means "doesn't exist"**
+
+## ✅ Solution - Build the Images
+
+You have two options:
+
+### Option 1: Create Main Branch and Trigger Build (Recommended)
+
+```bash
+# 1. Checkout your feature branch
+git checkout claude/review-previous-work-011CUuddWCWqDdX3EGaRui9T
+
+# 2. Create and push main branch from current state
+git checkout -b main
+git push -u origin main
+
+# 3. Wait for GitHub Actions to build (5-10 minutes)
+#    Monitor at: https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki/actions
+```
+
+### Option 2: Merge Feature Branch to Main via Pull Request
+
+1. **Create `main` branch first:**
+   - Go to: https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki
+   - Click "Branch: claude/review..." dropdown
+   - Type "main" and click "Create branch: main"
+
+2. **Create Pull Request:**
+   - Go to: https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki/pulls
+   - Click "New pull request"
+   - Base: `main` ← Compare: `claude/review-previous-work-011CUuddWCWqDdX3EGaRui9T`
+   - Click "Create pull request"
+   - Click "Merge pull request"
+
+3. **Monitor the build:**
+   - Go to: https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki/actions
+   - Wait for "Build TiddlyWiki Add-on" workflow to complete
+   - Should take 5-10 minutes to build all 5 architectures
+
+## 📦 After Build Completes - Make Packages Public
+
+GitHub Container Registry packages are **private by default**. You need to make them public:
+
+### Steps to Make Packages Public:
+
+1. **Go to your packages:**
+   ```
+   https://github.com/BenSweaterVest?tab=packages
+   ```
+
+2. **For EACH architecture package** (you'll have 5):
+   - Click on the package name (e.g., `amd64-hassio-tiddlywiki`)
+   - Click "Package settings" (right sidebar)
+   - Scroll down to "Danger Zone"
+   - Click "Change visibility"
+   - Select "Public"
+   - Type the package name to confirm
+   - Click "I understand, change package visibility"
+
+3. **Repeat for all 5 packages:**
+   - `amd64-hassio-tiddlywiki`
+   - `armhf-hassio-tiddlywiki`
+   - `armv7-hassio-tiddlywiki`
+   - `aarch64-hassio-tiddlywiki`
+   - `i386-hassio-tiddlywiki`
+
+## 🔧 Alternative: Update Workflow to Make Packages Public Automatically
+
+Add this to your `.github/workflows/build.yml` after the build step:
+
+```yaml
+      - name: Make package public
+        if: success()
+        run: |
+          # Note: This requires a Personal Access Token with packages:write scope
+          # For now, manually make packages public via GitHub UI
+          echo "Build complete. Make packages public via GitHub UI:"
+          echo "https://github.com/BenSweaterVest?tab=packages"
+```
+
+## ✅ Verification Steps
+
+After building and making packages public:
+
+1. **Check packages exist:**
+   ```bash
+   # Try to pull an image manually (from any machine)
+   docker pull ghcr.io/bensweetervest/amd64-hassio-tiddlywiki:latest
+   ```
+
+2. **Verify in GitHub:**
+   - Go to: https://github.com/BenSweaterVest?tab=packages
+   - Should see 5 packages listed
+   - Each should show "Public" badge
+
+3. **Test in Home Assistant:**
+   - Add repository URL to HA addon store
+   - Refresh addon list
+   - TiddlyWiki addon should appear
+   - Click Install
+   - Should download and install successfully
+
+## 🐛 Troubleshooting
+
+### Build Fails with "target not found"
+- Check that `tiddlywiki/` directory exists in repository
+- Verify `.github/workflows/build.yml` has `--target tiddlywiki`
+
+### Build Succeeds but Packages Still Don't Exist
+- Check GitHub Actions logs for actual completion
+- Verify authentication worked (no "denied" errors in logs)
+- Check packages tab: https://github.com/BenSweaterVest?tab=packages
+
+### Packages Exist but Still Get 403
+- Packages are still private - follow "Make Packages Public" steps above
+- Or: Verify package names match exactly (case-sensitive)
+
+### Build Takes Too Long
+- Building 5 architectures takes time
+- Typical build: 5-10 minutes total
+- Check Actions tab for progress
+
+## 📝 Current Workflow Trigger
+
+Your workflow only builds on:
+```yaml
+on:
+  push:
+    branches: [ main ]  # ← Only triggers on push to main
+  workflow_dispatch:    # ← Or manual trigger
+```
+
+**This means:**
+- ❌ Pushes to feature branches don't trigger builds
+- ✅ Pushes to `main` trigger automatic builds
+- ✅ Manual trigger works from Actions tab (if you have a main branch)
+
+## 🎯 Quick Fix Summary
+
+1. **Create `main` branch** from your feature branch
+2. **Push to `main`** to trigger GitHub Actions
+3. **Wait for build** to complete (~5-10 minutes)
+4. **Make packages public** via GitHub UI (5 packages)
+5. **Test installation** in Home Assistant
+
+## 📞 Next Steps
+
+After following these steps, if you still get errors:
+- Share the GitHub Actions build logs
+- Check which step failed
+- Verify package visibility settings
+
+The images MUST be built and public before Home Assistant can install them!
+
+---
+
+**Quick Links:**
+- Actions: https://github.com/BenSweaterVest/HomeAssistantTiddlyWiki/actions
+- Packages: https://github.com/BenSweaterVest?tab=packages
+- Workflow file: `.github/workflows/build.yml`


### PR DESCRIPTION
Issue Reported:
- Users getting 403 Forbidden errors trying to install addon
- Error: "denied" when pulling from ghcr.io/bensweetervest/amd64-hassio-tiddlywiki

Root Cause Identified:
- No 'main' branch exists in repository
- GitHub Actions workflow only triggers on push to main
- No Docker images have been built yet
- Images don't exist in GHCR → 403 error when users try to pull them

Solution Documentation Added:

1. TROUBLESHOOTING_403.md (Comprehensive Fix Guide):
   - Root cause analysis
   - Step-by-step fix instructions
   - Two deployment options (create main or PR merge)
   - Complete guide to making GHCR packages public
   - Verification steps
   - Troubleshooting for build failures
   - Quick fix summary

2. DEPLOYMENT_GUIDE.md (Complete Deployment Process):
   - Prerequisites checklist
   - 6-step deployment process
   - Detailed instructions for making packages public
   - Alternative automation with GitHub CLI
   - Comprehensive troubleshooting section
   - Deployment checklist for each release
   - Quick reference with all URLs and commands
   - Success criteria

3. Updated RELEASE_INSTRUCTIONS.md:
   - Added critical warning about building images first
   - Explained why no main branch = no images
   - Quick fix commands at top of file
   - Link to detailed troubleshooting guide

4. Updated README.md:
   - Added warning note in Installation section
   - Link to DEPLOYMENT_GUIDE.md for maintainers
   - Link to TROUBLESHOOTING_403.md for users getting errors

Key Points for Users:
- Docker images MUST be built before installation works
- GHCR packages default to PRIVATE - must manually make public
- All 5 architecture images need to be made public
- Build takes 5-10 minutes after pushing to main

Next Steps for Maintainer:
1. Create main branch from feature branch
2. Push to trigger GitHub Actions build
3. Wait for build to complete
4. Make all 5 packages public via GitHub UI
5. Test installation in Home Assistant